### PR TITLE
Don't warn on `assert_not_called`, `assert_called` or `assert_called_once`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,6 @@ List of non-existent methods checked
 ------------------------------------
 
     * ``assert_calls``
-    * ``assert_not_called``
-    * ``assert_called``
-    * ``assert_called_once``
     * ``not_called``
     * ``called_once``
     * ``called_once_with``

--- a/flake8_mock.py
+++ b/flake8_mock.py
@@ -10,9 +10,6 @@ __version__ = '0.2'
 
 NON_EXISTENT_METHODS = [
     'assert_calls',
-    'assert_not_called',
-    'assert_called',
-    'assert_called_once',
     'not_called',
     'called_once',
     'called_once_with',


### PR DESCRIPTION
New versions of mock provide these methods.
