### PR TITLE
Make flake8-mock compatible with flake8 >=5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     zip_safe=False,
     entry_points={
         'flake8.extension': [
-            'flake8_mock = flake8_mock:MockChecker',
+            'M = flake8_mock:MockChecker',
         ],
     },
     classifiers=[


### PR DESCRIPTION
Flake8 5.0.0+ enforces requirements around plugin prefixes on the error codes (https://github.com/pycqa/flake8/pull/1579). This should fix it, with thanks to https://github.com/globality-corp/flake8-logging-format/pull/33 for demonstrating the fix.